### PR TITLE
Return error if there are duplicate build step names

### DIFF
--- a/teamcity/resource_build_config.go
+++ b/teamcity/resource_build_config.go
@@ -826,11 +826,19 @@ func expandBuildFeature(raw interface{}) (api.BuildFeature, error) {
 func expandBuildSteps(list interface{}) ([]api.Step, error) {
 	out := make([]api.Step, 0)
 	in := list.([]interface{})
+	names := make(map[string]struct{})
 	for _, i := range in {
 		s, err := expandBuildStep(i)
 		if err != nil {
 			return nil, err
 		}
+
+		if _, exist := names[s.GetName()]; exist {
+			return nil, fmt.Errorf("Duplicate build step names '%s'", s.GetName())
+		} else {
+			names[s.GetName()] = struct{}{}
+		}
+
 		out = append(out, s)
 	}
 


### PR DESCRIPTION
[Story(SB-8977)](https://yexttest.atlassian.net/browse/SB-8977?atlOrigin=eyJpIjoiYTU4MmUzNjdiZGU0NGNkZjg5YjUwNTdlNzhiZTE0NTkiLCJwIjoiaiJ9): CI CaC - Duplicate step names puts Entrypoint in infinite loop

Return error if there are duplicate build step names
