### PR TITLE
support update to cron_schedule in teamcity_build_trigger_schedule

### DIFF
--- a/teamcity/resource_build_trigger_schedule.go
+++ b/teamcity/resource_build_trigger_schedule.go
@@ -76,30 +76,37 @@ func resourceBuildTriggerSchedule() *schema.Resource {
 						"seconds": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 						"minutes": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 						"hours": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 						"day_of_month": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 						"month": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 						"day_of_week": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 						"year": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 					},
 				},


### PR DESCRIPTION
tested locally on updating the cron_schedule value, trigger_schedule
resource was deleted and recreated instead of showing an error not
able to update