### PR TITLE
Avoid destructive actions when deleting projects and buildconfigs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/hashicorp/terraform v0.12.2
 	github.com/robfig/cron v1.2.0
-	github.com/yext/go-teamcity v0.5.3-0.20230323164551-08f28b0ad89b
+	github.com/yext/go-teamcity v0.5.3
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -344,10 +344,8 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6Ac
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
-github.com/yext/go-teamcity v0.5.2 h1:SETbrxEDeK2p7bjJJOCcCFHSKUGzsowGqpu1ypeUH0E=
-github.com/yext/go-teamcity v0.5.2/go.mod h1:GC2xvLY4y27DU/01mveI8LsSBerjpCEtHk6eQ7ym8oc=
-github.com/yext/go-teamcity v0.5.3-0.20230323164551-08f28b0ad89b h1:EEtPT+W2T28FKBX/v3HUWpNRjoZMX0R8TgHNZnZdEWw=
-github.com/yext/go-teamcity v0.5.3-0.20230323164551-08f28b0ad89b/go.mod h1:GC2xvLY4y27DU/01mveI8LsSBerjpCEtHk6eQ7ym8oc=
+github.com/yext/go-teamcity v0.5.3 h1:kO8of1jNql70g9fURGs+oM0ArMX3csjGy99FAkPecEQ=
+github.com/yext/go-teamcity v0.5.3/go.mod h1:GC2xvLY4y27DU/01mveI8LsSBerjpCEtHk6eQ7ym8oc=
 github.com/zclconf/go-cty v0.0.0-20181129180422-88fbe721e0f8/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v0.0.0-20190426224007-b18a157db9e2/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v0.0.0-20190516203816-4fecf87372ec/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=

--- a/teamcity/resource_project.go
+++ b/teamcity/resource_project.go
@@ -1,10 +1,11 @@
 package teamcity
 
 import (
+	"fmt"
 	"log"
 
-	api "github.com/yext/go-teamcity/teamcity"
 	"github.com/hashicorp/terraform/helper/schema"
+	api "github.com/yext/go-teamcity/teamcity"
 )
 
 func resourceProject() *schema.Resource {
@@ -12,7 +13,7 @@ func resourceProject() *schema.Resource {
 		Create: resourceProjectCreate,
 		Read:   resourceProjectRead,
 		Update: resourceProjectUpdate,
-		Delete: resourceProjectDelete,
+		Delete: resourceProjectArchive,
 		Importer: &schema.ResourceImporter{
 			State: resourceProjectImport,
 		},
@@ -152,9 +153,16 @@ func resourceProjectRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceProjectDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceProjectArchive(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
-	return client.Projects.Delete(d.Id())
+
+	err := client.Projects.Archive(d.Id())
+	if err != nil {
+		return err
+	}
+
+	name := d.Get("name")
+	return client.Projects.Rename(d.Id(), fmt.Sprintf("%s (Archived)", name.(string)))
 }
 
 func resourceProjectImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {


### PR DESCRIPTION
Instead of deleting buildconfigs:
- Pause buildconfig
- Remove all build steps
- Rename to have an (Archived) suffix

Instead of deleting projects:
- Archive project
- Rename to have an (Archived) suffix