### PR TITLE
Delete Coverage build instead of archive

### DIFF
--- a/teamcity/resource_build_config.go
+++ b/teamcity/resource_build_config.go
@@ -434,6 +434,12 @@ func resourceBuildConfigUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceBuildConfigArchive(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 
+	// Delete the build config if the name is "Coverage"
+	// We are bulk retiring all the Coverage builds, which we prefer to delete over archive them
+	if d.Get("name") == "Coverage" {
+		return client.BuildTypes.Delete(d.Id())
+	}
+
 	err := client.BuildTypes.Pause(d.Id())
 	if err != nil {
 		return err


### PR DESCRIPTION
J=SB-11134

This is needed for retiring all Coverage builds
Tested by removing a coverage build from tf, and it was successfully deleted