### PR TITLE
Revert: Delete Coverage build instead of archive

### DIFF
--- a/teamcity/resource_build_config.go
+++ b/teamcity/resource_build_config.go
@@ -434,12 +434,6 @@ func resourceBuildConfigUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceBuildConfigArchive(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*api.Client)
 
-	// Delete the build config if the name is "Coverage"
-	// We are bulk retiring all the Coverage builds, which we prefer to delete over archive them
-	if d.Get("name") == "Coverage" {
-		return client.BuildTypes.Delete(d.Id())
-	}
-
 	err := client.BuildTypes.Pause(d.Id())
 	if err != nil {
 		return err


### PR DESCRIPTION
All Coverage builds have been deleted, reverting this change back to original:
https://github.com/yext/terraform-provider-teamcity/commit/8b8b164b670cb4e742f650505428be7648bd8a43

J=SB-11134