### PR TITLE
Allow moves on buildconfig project id updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/hashicorp/terraform v0.12.2
 	github.com/robfig/cron v1.2.0
-	github.com/yext/go-teamcity v0.5.5
+	github.com/yext/go-teamcity v0.5.6
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -344,8 +344,8 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6Ac
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
-github.com/yext/go-teamcity v0.5.5 h1:3YiCouF6FUqHZku3rSHR9SN3tA1CN+idrMqllydj1yA=
-github.com/yext/go-teamcity v0.5.5/go.mod h1:GC2xvLY4y27DU/01mveI8LsSBerjpCEtHk6eQ7ym8oc=
+github.com/yext/go-teamcity v0.5.6 h1:0cNc9/FduD4Oaj0gqhNnTlfuePJPlqPGY6EYPbWJaAo=
+github.com/yext/go-teamcity v0.5.6/go.mod h1:GC2xvLY4y27DU/01mveI8LsSBerjpCEtHk6eQ7ym8oc=
 github.com/zclconf/go-cty v0.0.0-20181129180422-88fbe721e0f8/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v0.0.0-20190426224007-b18a157db9e2/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v0.0.0-20190516203816-4fecf87372ec/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=

--- a/teamcity/resource_build_config.go
+++ b/teamcity/resource_build_config.go
@@ -71,7 +71,6 @@ func resourceBuildConfig() *schema.Resource {
 			"project_id": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -305,6 +304,14 @@ func resourceBuildConfigUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("name") {
 		v := d.Get("name")
 		err = client.BuildTypes.Rename(d.Id(), v.(string))
+		if err != nil {
+			return err
+		}
+	}
+
+	if d.HasChange("project_id") {
+		v := d.Get("project_id")
+		err = client.BuildTypes.Move(d.Id(), v.(string))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Instead of forcing a replacement (archiving + recreate), temporarily allow moves to the new parent project. This will not be a permanent change because if the old parent project is being archived in the same update, the buildconfig will also end up being archived by TeamCity first, as deletions happen before updates.