### PR TITLE
Add option to vcs triggers to trigger on snapshot dependency changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/hashicorp/terraform v0.12.2
 	github.com/robfig/cron v1.2.0
-	github.com/yext/go-teamcity v0.5.6
+	github.com/yext/go-teamcity v0.5.7
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -344,8 +344,8 @@ github.com/vmihailenco/msgpack v4.0.4+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6Ac
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20161029104018-1d6e34225557/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
-github.com/yext/go-teamcity v0.5.6 h1:0cNc9/FduD4Oaj0gqhNnTlfuePJPlqPGY6EYPbWJaAo=
-github.com/yext/go-teamcity v0.5.6/go.mod h1:GC2xvLY4y27DU/01mveI8LsSBerjpCEtHk6eQ7ym8oc=
+github.com/yext/go-teamcity v0.5.7 h1:arwJ0F7VCCcqAwlOTRbfW+2cBzzFOWy+aJftHjXiKdY=
+github.com/yext/go-teamcity v0.5.7/go.mod h1:GC2xvLY4y27DU/01mveI8LsSBerjpCEtHk6eQ7ym8oc=
 github.com/zclconf/go-cty v0.0.0-20181129180422-88fbe721e0f8/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v0.0.0-20190426224007-b18a157db9e2/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v0.0.0-20190516203816-4fecf87372ec/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=

--- a/teamcity/resource_build_trigger_vcs.go
+++ b/teamcity/resource_build_trigger_vcs.go
@@ -3,8 +3,8 @@ package teamcity
 import (
 	"fmt"
 
-	api "github.com/yext/go-teamcity/teamcity"
 	"github.com/hashicorp/terraform/helper/schema"
+	api "github.com/yext/go-teamcity/teamcity"
 )
 
 func resourceBuildTriggerVcs() *schema.Resource {
@@ -33,6 +33,12 @@ func resourceBuildTriggerVcs() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"snapshot_dependency_triggers": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
 			},
 		},
 	}
@@ -64,6 +70,10 @@ func resourceBuildTriggerVcsCreate(d *schema.ResourceData, meta interface{}) err
 
 	if v, ok := d.GetOk("branch_filter"); ok {
 		dt.BranchFilter = expandStringSlice(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("snapshot_dependency_triggers"); ok {
+		dt.Options.SnapshotDependencyTriggers = v.(bool)
 	}
 
 	out, err := ts.AddTrigger(dt)

--- a/teamcity/resource_build_trigger_vcs.go
+++ b/teamcity/resource_build_trigger_vcs.go
@@ -34,7 +34,7 @@ func resourceBuildTriggerVcs() *schema.Resource {
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"snapshot_dependency_triggers": {
+			"trigger_on_snapshot_dependency_changes": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
@@ -72,7 +72,7 @@ func resourceBuildTriggerVcsCreate(d *schema.ResourceData, meta interface{}) err
 		dt.BranchFilter = expandStringSlice(v.([]interface{}))
 	}
 
-	if v, ok := d.GetOk("snapshot_dependency_triggers"); ok {
+	if v, ok := d.GetOk("trigger_on_snapshot_dependency_changes"); ok {
 		dt.Options.SnapshotDependencyTriggers = v.(bool)
 	}
 
@@ -113,6 +113,10 @@ func resourceBuildTriggerVcsRead(d *schema.ResourceData, meta interface{}) error
 		if err := d.Set("branch_filter", dt.BranchFilter); err != nil {
 			return err
 		}
+	}
+
+	if err := d.Set("trigger_on_snapshot_dependency_changes", dt.Options.SnapshotDependencyTriggers); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
VCS triggers have a checkbox "Trigger a build on changes in snapshot dependencies". The TeamCity Go client has been updated, and can be used in the terraform provider.

TEST=manual

Applied a pipeline with a VCS trigger to a local TeamCity before the provider change, verified that no changes were detected after the provider change, and `trigger_on_snapshot_dependency_changes = true` can now be set in the trigger